### PR TITLE
The tar extraction path is incorrect

### DIFF
--- a/ruby/ruby.go
+++ b/ruby/ruby.go
@@ -35,7 +35,7 @@ func NewContributor(context build.Build) (Contributor, bool, error) {
 func (c Contributor) Contribute() error {
 	return c.layer.Contribute(func(artifact string, layer layers.DependencyLayer) error {
 		layer.Logger.SubsequentLine("Expanding to %s", layer.Root)
-		if err := helper.ExtractTarGz(artifact, layer.Root, 1); err != nil {
+		if err := helper.ExtractTarGz(artifact, layer.Root, 0); err != nil {
 			return err
 		}
 		return nil


### PR DESCRIPTION
Hi team!
I have happend this error message `mkdir /layers/org.cloudfoundry.ruby/ruby/ruby: not a directory`

```
vcap@c82cea1e9941:/layers$ /lifecycle/analyzer -layers=/layers  -group=/layers/group.toml pyama/test
Warning: Image 'pyama/test' not found
vcap@c82cea1e9941:/layers$ /lifecycle/builder -app=/workspace/source -group=/layers/group.toml -plan=/layers/plan.toml -layers=/layers
-----> Ruby Buildpack &{[34] <nil>}
  Ruby 2.6.5: Contributing to layer
    Downloading from https://buildpacks.cloudfoundry.org/dependencies/ruby/ruby-2.6.5-linux-x64-cflinuxfs3-a23c26ec.tgz
    Verifying checksum
       Expanding to /layers/org.cloudfoundry.ruby/ruby /layers/org.cloudfoundry.ruby/a23c26ec93e34ca05328390107ff40034b5103afb91194ebf70f66f0c0866db4/ruby-2.6.5-linux-x64-cflinuxfs3-a23c26ec.tgz

mkdir /layers/org.cloudfoundry.ruby/ruby/ruby: not a directory
ERROR: failed to build: exit status 103

```

I think, This is due to the tar structure.

```
vcap@c82cea1e9941:/layers$ tar tvf /layers/org.cloudfoundry.ruby/a23c26ec93e34ca05328390107ff40034b5103afb91194ebf70f66f0c0866db4/ruby-2.6.5-linux-x64-cflinuxfs3-a23c26ec.tgz | head
drwxr-xr-x root/root         0 2019-10-01 13:13 bin/
-rwxr-xr-x root/root  18354416 2019-10-01 13:13 bin/ruby
-rwxr-xr-x root/root       624 2019-10-01 13:13 bin/bundle
-rwxr-xr-x root/root       626 2019-10-01 13:13 bin/bundler
-rwxr-xr-x root/root      5180 2019-10-01 13:13 bin/erb
-rwxr-xr-x root/root       640 2019-10-01 13:13 bin/gem
-rwxr-xr-x root/root       602 2019-10-01 13:13 bin/irb
-rwxr-xr-x root/root       608 2019-10-01 13:13 bin/rdoc
-rwxr-xr-x root/root       604 2019-10-01 13:13 bin/ri
-rwxr-xr-x root/root       606 2019-10-01 13:13 bin/rake
```

If you import this patch, you can install ruby successfully.

Thanks.
refs: https://github.com/cloudfoundry/bundler-cnb/pull/3