### PR TITLE
Remove ruby 2.4.x and make 2.7.x as default

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -9,44 +9,7 @@ api = "0.2"
   include_files = ["bin/build", "bin/detect", "buildpack.toml"]
   pre_package = "./scripts/build.sh"
   [metadata.default-versions]
-    ruby = "2.4.*"
-
-  [[metadata.dependencies]]
-    id = "ruby"
-    name = "Ruby"
-    sha256 = "3131cb19beeee3701e905bb1738817c5af8be7c150994510e956a1cba98a8ade"
-    stacks = ["org.cloudfoundry.stacks.cflinuxfs2"]
-    uri = "https://buildpacks.cloudfoundry.org/dependencies/ruby/ruby-2.4.5-linux-x64-cflinuxfs2-3131cb19.tgz"
-    version = "2.4.5"
-
-  [[metadata.dependencies]]
-    id = "ruby"
-    sha256 = "3f9ed717d4c7e5aa1a871518c051487f78567af7ea71ea6ff3bab1b30078663f"
-    source = "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.6.tar.gz"
-    source_sha256 = "de0dc8097023716099f7c8a6ffc751511b90de7f5694f401b59f2d071db910be"
-    stacks = ["org.cloudfoundry.stacks.cflinuxfs2"]
-    uri = "https://buildpacks.cloudfoundry.org/dependencies/ruby/ruby-2.4.6-linux-x64-cflinuxfs2-3f9ed717.tgz"
-    version = "2.4.6"
-
-  [[metadata.dependencies]]
-    id = "ruby"
-    name = "Ruby"
-    sha256 = "7fa6c6086a7c2db0d0b0c05718fab5c1983216f85f3c7fad69930de39b75078d"
-    source = "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.8.tar.gz"
-    source_sha256 = "37f0d180afa56ec3e7a3669c6f1b6ee8a47a811261f0e1afa8f817c8b577bd68"
-    stacks = ["org.cloudfoundry.stacks.cflinuxfs3"]
-    uri = "https://buildpacks.cloudfoundry.org/dependencies/ruby/ruby-2.4.8-linux-x64-cflinuxfs3-7fa6c608.tgz"
-    version = "2.4.8"
-
-  [[metadata.dependencies]]
-    id = "ruby"
-    name = "Ruby"
-    sha256 = "b8eb2847eea8c77c81cd9491580d506375d0dfcf40d83c62276ba1722cb475ac"
-    source = "https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.9.tar.gz"
-    source_sha256 = "f99b6b5e3aa53d579a49eb719dd0d3834d59124159a6d4351d1e039156b1c6ae"
-    stacks = ["org.cloudfoundry.stacks.cflinuxfs3"]
-    uri = "https://buildpacks.cloudfoundry.org/dependencies/ruby/ruby-2.4.9-linux-x64-cflinuxfs3-b8eb2847.tgz"
-    version = "2.4.9"
+    ruby = "2.7.*"
 
   [[metadata.dependencies]]
     id = "ruby"
@@ -125,10 +88,10 @@ api = "0.2"
     version = "2.7.0"
 
   [[metadata.dependency_deprecation_dates]]
-    date = 2020-04-01T00:00:00Z
+    date = 2023-04-01T00:00:00Z
     link = "https://www.ruby-lang.org/en/news/2019/04/01/ruby-2-4-6-released/"
     name = "ruby"
-    version_line = "2.4.x"
+    version_line = "2.7.x"
 
 [[stacks]]
   id = "org.cloudfoundry.stacks.cflinuxfs3"

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -89,7 +89,7 @@ api = "0.2"
 
   [[metadata.dependency_deprecation_dates]]
     date = 2023-04-01T00:00:00Z
-    link = "https://www.ruby-lang.org/en/news/2019/04/01/ruby-2-4-6-released/"
+    link = "https://www.ruby-lang.org/en/news/2020/03/31/ruby-2-7-1-released/"
     name = "ruby"
     version_line = "2.7.x"
 


### PR DESCRIPTION
[#171609722]

Thanks for contributing to the buildpack. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* [ ] I have viewed signed and have submitted the Contributor License Agreement

* [ ] I have made this pull request to the `develop` branch

* [ ] I have added an integration test
