### PR TITLE
Adds GEM_PATH to the shared environment

### DIFF
--- a/cmd/build/main.go
+++ b/cmd/build/main.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/cloudfoundry/packit"
 	"github.com/cloudfoundry/packit/cargo"
+	"github.com/cloudfoundry/packit/pexec"
 	"github.com/cloudfoundry/packit/postal"
 	"github.com/cloudfoundry/ruby-mri-cnb/ruby"
 )
@@ -16,6 +17,7 @@ func main() {
 	dependencyManager := postal.NewService(cargo.NewTransport())
 	planRefinery := ruby.NewPlanRefinery()
 	clock := ruby.NewClock(time.Now)
+	gem := pexec.NewExecutable("gem")
 
-	packit.Build(ruby.Build(entryResolver, dependencyManager, planRefinery, logEmitter, clock))
+	packit.Build(ruby.Build(entryResolver, dependencyManager, planRefinery, logEmitter, clock, gem))
 }

--- a/integration/logging_test.go
+++ b/integration/logging_test.go
@@ -64,6 +64,8 @@ func testLogging(t *testing.T, context spec.G, it spec.S) {
 				MatchRegexp(`    Installing Ruby MRI 2\.7\.\d+`),
 				MatchRegexp(`      Completed in \d+\.\d+`),
 				"",
+				"  Configuring environment",
+				MatchRegexp(`    GEM_PATH -> "/home/vcap/.gem/ruby/2\.7\.\d+:/layers/org.cloudfoundry.ruby-mri/ruby/lib/ruby/gems/2\.7\.\d+"`),
 			}
 
 			Expect(GetBuildLogs(logs.String())).To(ContainSequence(sequence), logs.String())

--- a/integration/reuse_layer_rebuild_test.go
+++ b/integration/reuse_layer_rebuild_test.go
@@ -89,6 +89,9 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 				"  Executing build process",
 				MatchRegexp(`    Installing Ruby MRI 2\.\d+\.\d+`),
 				MatchRegexp(`      Completed in \d+\.\d+`),
+				"",
+				"  Configuring environment",
+				MatchRegexp(`    GEM_PATH -> "/home/vcap/.gem/ruby/2\.7\.\d+:/layers/org.cloudfoundry.ruby-mri/ruby/lib/ruby/gems/2\.7\.\d+"`),
 			}), logs.String())
 
 			firstContainer, err = docker.Container.Run.WithMemory("128m").WithCommand("ruby run.rb").Execute(firstImage.ID)
@@ -179,6 +182,9 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 				"  Executing build process",
 				MatchRegexp(`    Installing Ruby MRI 2\.7\.\d+`),
 				MatchRegexp(`      Completed in \d+\.\d+`),
+				"",
+				"  Configuring environment",
+				MatchRegexp(`    GEM_PATH -> "/home/vcap/.gem/ruby/2\.7\.\d+:/layers/org.cloudfoundry.ruby-mri/ruby/lib/ruby/gems/2\.7\.\d+"`),
 			}), logs.String())
 
 			firstContainer, err = docker.Container.Run.WithMemory("128m").WithCommand("ruby run.rb").Execute(firstImage.ID)
@@ -212,6 +218,9 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 				"  Executing build process",
 				MatchRegexp(`    Installing Ruby MRI 2\.6\.\d+`),
 				MatchRegexp(`      Completed in \d+\.\d+`),
+				"",
+				"  Configuring environment",
+				MatchRegexp(`    GEM_PATH -> "/home/vcap/.gem/ruby/2\.6\.\d+:/layers/org.cloudfoundry.ruby-mri/ruby/lib/ruby/gems/2\.6\.\d+"`),
 			}), logs.String())
 
 			secondContainer, err = docker.Container.Run.WithMemory("128m").WithCommand("ruby run.rb").Execute(secondImage.ID)

--- a/ruby/fakes/executable.go
+++ b/ruby/fakes/executable.go
@@ -1,0 +1,32 @@
+package fakes
+
+import (
+	"sync"
+
+	"github.com/cloudfoundry/packit/pexec"
+)
+
+type Executable struct {
+	ExecuteCall struct {
+		sync.Mutex
+		CallCount int
+		Receives  struct {
+			Execution pexec.Execution
+		}
+		Returns struct {
+			Error error
+		}
+		Stub func(pexec.Execution) error
+	}
+}
+
+func (f *Executable) Execute(param1 pexec.Execution) error {
+	f.ExecuteCall.Lock()
+	defer f.ExecuteCall.Unlock()
+	f.ExecuteCall.CallCount++
+	f.ExecuteCall.Receives.Execution = param1
+	if f.ExecuteCall.Stub != nil {
+		return f.ExecuteCall.Stub(param1)
+	}
+	return f.ExecuteCall.Returns.Error
+}

--- a/ruby/log_emitter.go
+++ b/ruby/log_emitter.go
@@ -75,3 +75,9 @@ func (e LogEmitter) Candidates(entries []packit.BuildpackPlanEntry) {
 
 	e.Break()
 }
+
+func (l LogEmitter) Environment(env packit.Environment) {
+	l.Process("Configuring environment")
+	l.Subprocess("%s", scribe.NewFormattedMapFromEnvironment(env))
+	l.Break()
+}

--- a/ruby/log_emitter_test.go
+++ b/ruby/log_emitter_test.go
@@ -151,4 +151,15 @@ func testLogEmitter(t *testing.T, context spec.G, it spec.S) {
 			Expect(buffer.String()).To(ContainSubstring("      <unknown>     -> \"*\""))
 		})
 	})
+
+	context("Environment", func() {
+		it("prints details about the environment", func() {
+			emitter.Environment(packit.Environment{
+				"GEM_PATH.override": "/some/path",
+			})
+
+			Expect(buffer.String()).To(ContainSubstring("  Configuring environment"))
+			Expect(buffer.String()).To(ContainSubstring("    GEM_PATH -> \"/some/path\""))
+		})
+	})
 }


### PR DESCRIPTION
This allows subsequent buildpacks to append to this path without losing the value that is set as the default for the installed version of ruby. It is needed so that the bundler CNB can append onto this path.